### PR TITLE
Add mainnet-fork support

### DIFF
--- a/Mainnet_fork/Readme.md
+++ b/Mainnet_fork/Readme.md
@@ -1,7 +1,7 @@
 # Mainnet Fork setup
 
 ## Overview
-This ansible playbook automates the mainnet fork setup. Additionally, it also sets up an explorer and faucet.This playbook is primarily intended for testing purpose.
+This Ansible playbook automates the mainnet fork setup. Additionally, it sets up an explorer and a faucet. This playbook is primarily intended for testing purposes.
 
 ## Components
 1. Validator Node
@@ -19,10 +19,10 @@ This ansible playbook automates the mainnet fork setup. Additionally, it also se
 All necessary software installations are performed on the respective server, ensuring each node has the required dependencies and configurations.
 
 2. Validator Setup
-The blockchain network is setup consisting of a validator node and a fullnode
+The blockchain network is set up consisting of a validator node and a fullnode
 
 3. Cosmos Genesis Tinkerer
-The Cosmos Genesis Tinkerer scripts are run to imitate a test environment and creates a network genesis file.
+The Cosmos Genesis Tinkerer scripts simulate a test environment and create a network genesis file.
 
 4. Node Config changes
 Node configuration changes are done based on the user requirements.
@@ -46,6 +46,8 @@ An upgrade proposal is submitted to the blockchain network to perform an automat
 
 4. Run the playbook using the command :
 
-```ini
+```bash
 ansible-playbook main.yml  -i inventory.ini
 ```
+
+5. To view the explorer, enter the server IP. For the faucet, enter server IP:83.

--- a/Mainnet_fork/Readme.md
+++ b/Mainnet_fork/Readme.md
@@ -1,0 +1,51 @@
+# Mainnet Fork setup
+
+## Overview
+This ansible playbook automates the mainnet fork setup. Additionally, it also sets up an explorer and faucet.This playbook is primarily intended for testing purpose.
+
+## Components
+1. Validator Node
+2. Full node
+3. Explorer
+4. Faucet
+
+## Pre-requisites
+1. Ansible
+2. Server with public IP address and SSH access
+
+## How it works
+
+1. Installations
+All necessary software installations are performed on the respective server, ensuring each node has the required dependencies and configurations.
+
+2. Validator Setup
+The blockchain network is setup consisting of a validator node and a fullnode
+
+3. Cosmos Genesis Tinkerer
+The Cosmos Genesis Tinkerer scripts are run to imitate a test environment and creates a network genesis file.
+
+4. Node Config changes
+Node configuration changes are done based on the user requirements.
+
+5. Cosmovisor Setup
+A cosmovisor setup is done to automate network upgrades for both the validator and the fullnode.
+
+6. Explorer and Faucet Setup
+After the nodes are operational, an explorer and a faucet are set up for the blockchain network. The faucet allows users to request test funds for the network, while the explorer (built using Node.js, Yarn, and Nginx) connects to the blockchain to provide real-time data about the network.
+
+7. Proposal Setup
+An upgrade proposal is submitted to the blockchain network to perform an automated upgrade
+
+# Steps to deploy the playbook
+
+1. Clone the github repository.
+
+2. In the inventory file make the changes as per your requirement
+
+3. In the faucet-config.j2 file present in the templates make changes as per your requirements.
+
+4. Run the playbook using the command :
+
+```ini
+ansible-playbook main.yml  -i inventory.ini
+```

--- a/Mainnet_fork/inventory.ini
+++ b/Mainnet_fork/inventory.ini
@@ -5,33 +5,75 @@ server ansible_host=a.b.c.d ansible_user=root
 [all:vars]
 
 user_home="{{ ansible_env.HOME }}"
+
 path="/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:{{ user_home }}/go/bin"
-network=passage#github repo name
-node_home=.passage#the node home for the chain
-daemon=passage#the daemon name of the network
-node_version=v2.4.0#Current node version of the chain
-network_upgrade_version=v2.5.0#The version you want to upgrade to
-network_upgrade_name=v2.5#The upgrade plan name specified
-repo=https://github.com/envadiv/Passage3D#The network repo url       
-denom=upasg#The denom of the network
-minimum_gas_price=12.5upasg#The minimum gas prices
-go_version=1.21.6#Go version for the project
-state_export_file_path=/root/passage-export-12591387.json#The path to state export file present on the same server where the playbook runs
-validator_name=passage-validator#The name of the validator
-fullnode_name=passage-fullnode#The name of the fullnode
-sdk_version=v0.45.16#The sdk version used in the project. Please specify the full version
-addr_prefix=pasg#The address prefix of the network
+#github repo name
+network=passage
+
+#the node home for the chain
+node_home=.passage
+
+#the daemon name of the network
+daemon=passage
+
+#Current node version of the chain
+node_version=v2.4.0
+
+#The version you want to upgrade to
+network_upgrade_version=v2.5.0
+
+#The upgrade plan name specified
+network_upgrade_name=v2.5
+
+#The network repo url
+repo=https://github.com/envadiv/Passage3D
+
+#The denom of the network
+denom=upasg
+
+#The minimum gas price of the network
+minimum_gas_price=12.5upasg
+
+#Go version for the project
+go_version=1.21.6
+
+#The path to state export file present on local machine where ansible is running
+state_export_file_path=/root/passage-export-12591387.json
+
+#The name of the validator
+validator_name=passage-validator
+
+#The name of the fullnode
+fullnode_name=passage-fullnode
+
+#The sdk version used in the project. Please specify the full version
+sdk_version=v0.45.16
+
+#The address prefix of the network
+addr_prefix=pasg
+
 ping_repo="https://github.com/ping-pub/explorer.git"
-upgrade_height=12591507#The upgrade height where the network upgrade takes place
-upgrade_deposit=1000#The upgrade deposit
 
+#The upgrade height where the network upgrade takes place
+upgrade_height=12591507
 
+#The upgrade deposit required for the  network upgrade
+upgrade_deposit=1000
 
+#Self delegation address of the top validator in the network
+top_self_delegation_address=pasg1fcwhweq2qtd5aj702v4pj0apfxt8nrgp68thu3
 
+#Self delegation public key of the top validator in the network
+top_self_delegation_public_key=Arrzn+YFjqXhmr8/QtO+uymFwrXIJsmYTZ/Lltwfj4mA
 
-top_self_delegation_address=pasg1fcwhweq2qtd5aj702v4pj0apfxt8nrgp68thu3# Self delegation address of the top validator in the network
-top_self_delegation_public_key=Arrzn+YFjqXhmr8/QtO+uymFwrXIJsmYTZ/Lltwfj4mA# Self delegation public key of the top validator in the network
-top_operator_address=pasgvaloper1fcwhweq2qtd5aj702v4pj0apfxt8nrgpfmplad# The valoperator address of the validator
-top_operator_pubkey=ZLE8kDUgXL4SpaMa2rKouWNBLjo+lXkSlkb92SsWXxA=# The valoper public key of the validator
-top_hexaddr=0173FD24D68B059940736F29EEB5083D98F7AA44# The hex address of the validator
-top_consensus_address=pasgvalcons1q9el6fxk3vzejsrndu57adgg8kv002jy3sanfe# The consensus address of the validator
+#The valoperator address of the validator
+top_operator_address=pasgvaloper1fcwhweq2qtd5aj702v4pj0apfxt8nrgpfmplad
+
+#The valoper public key of the validator
+top_operator_pubkey=ZLE8kDUgXL4SpaMa2rKouWNBLjo+lXkSlkb92SsWXxA=
+
+#The hex address of the validator
+top_hexaddr=0173FD24D68B059940736F29EEB5083D98F7AA44
+
+# The consensus address of the validator
+top_consensus_address=pasgvalcons1q9el6fxk3vzejsrndu57adgg8kv002jy3sanfe

--- a/Mainnet_fork/inventory.ini
+++ b/Mainnet_fork/inventory.ini
@@ -6,32 +6,32 @@ server ansible_host=a.b.c.d ansible_user=root
 
 user_home="{{ ansible_env.HOME }}"
 path="/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:{{ user_home }}/go/bin"
-network= #github repo name ex: passage
-node_home= #the node home for the chain ex:'.passage'
-daemon= #the daemon name of the network ex:passage
-node_version= #Current node version of the chain ex:v2.4.0
-network_upgrade_version=#The version you want to upgrade to ex:v2.5.0
-network_upgrade_name=#The upgrade plan name specified ex:v2.5
-repo= #The network repo url https://github.com/envadiv/Passage3D       
-denom=# The denom of the network ex:upasg
-minimum_gas_price=#The minimum gas price ex: 12.5upasg
-go_version=#Go version for the project ex:1.21.6
-state_export_file_path=#The path to state export file present on the same server where the playbook runs ex:"/root/passage-export-12591387.json"
-validator_name=#The name of the validator ex: passage-validator
-fullnode_name=#The name of the fullnode ex: passage-fullnode
-sdk_version=#The sdk version used in the project. Please specify the full version ex :"v0.45.16"
-addr_prefix=#The address prefix o the network ex:"pasg"
+network=passage#github repo name
+node_home=.passage#the node home for the chain
+daemon=passage#the daemon name of the network
+node_version=v2.4.0#Current node version of the chain
+network_upgrade_version=v2.5.0#The version you want to upgrade to
+network_upgrade_name=v2.5#The upgrade plan name specified
+repo=https://github.com/envadiv/Passage3D#The network repo url       
+denom=upasg#The denom of the network
+minimum_gas_price=12.5upasg#The minimum gas prices
+go_version=1.21.6#Go version for the project
+state_export_file_path=/root/passage-export-12591387.json#The path to state export file present on the same server where the playbook runs
+validator_name=passage-validator#The name of the validator
+fullnode_name=passage-fullnode#The name of the fullnode
+sdk_version=v0.45.16#The sdk version used in the project. Please specify the full version
+addr_prefix=pasg#The address prefix of the network
 ping_repo="https://github.com/ping-pub/explorer.git"
-upgrade_height=#The upgrade height where the network upgrade takes place ex:12591507
-upgrade_deposit=#The upgrade deposit ex: 1000
+upgrade_height=12591507#The upgrade height where the network upgrade takes place
+upgrade_deposit=1000#The upgrade deposit
 
 
 
 
 
-top_self_delegation_address=# Self delegation address of the top validator in the network
-top_self_delegation_public_key=# Self delegation public key of the top validator in the network
-top_operator_address=# The valoperator address of the validator
-top_operator_pubkey=# The valoper public key of the validator
-top_hexaddr=# The hex address of the validator
-top_consensus_address=# The consensus address of the validator
+top_self_delegation_address=pasg1fcwhweq2qtd5aj702v4pj0apfxt8nrgp68thu3# Self delegation address of the top validator in the network
+top_self_delegation_public_key=Arrzn+YFjqXhmr8/QtO+uymFwrXIJsmYTZ/Lltwfj4mA# Self delegation public key of the top validator in the network
+top_operator_address=pasgvaloper1fcwhweq2qtd5aj702v4pj0apfxt8nrgpfmplad# The valoperator address of the validator
+top_operator_pubkey=ZLE8kDUgXL4SpaMa2rKouWNBLjo+lXkSlkb92SsWXxA=# The valoper public key of the validator
+top_hexaddr=0173FD24D68B059940736F29EEB5083D98F7AA44# The hex address of the validator
+top_consensus_address=pasgvalcons1q9el6fxk3vzejsrndu57adgg8kv002jy3sanfe# The consensus address of the validator

--- a/Mainnet_fork/inventory.ini
+++ b/Mainnet_fork/inventory.ini
@@ -1,0 +1,37 @@
+[IP]
+server ansible_host=a.b.c.d ansible_user=root
+
+
+[all:vars]
+
+user_home="{{ ansible_env.HOME }}"
+path="/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:/{{ user_home }}/go/bin"
+network= #github repo name ex: passage
+node_home= #the node home for the chain ex:'.passage'
+daemon= #the daemon name of the network ex:passage
+node_version= #Current node version of the chain ex:v2.4.0
+network_upgrade_version=#The version you want to upgrade to ex:v2.5.0
+network_upgrade_name=#The upgrade plan name specified ex:v2.5
+repo= #The network repo url https://github.com/envadiv/Passage3D       
+denom=# The denom of the network ex:upasg
+minimum_gas_price=#The minimum gas price ex: 12.5upasg
+go_version=#Go version for the project ex:1.21.6
+state_export_file_path=#The path to state export file present on the same server where the playbook runs ex:"/root/passage-export-12591387.json"
+validator_name=#The name of the validator ex: passage-validator
+fullnode_name=#The name of the fullnode ex: passage-fullnode
+sdk_version=#The sdk version used in the project. Please specify the full version ex :"v0.45.16"
+addr_prefix=#The address prefix o the network ex:"pasg"
+ping_repo="https://github.com/ping-pub/explorer.git"
+upgrade_height=#The upgrade height where the network upgrade takes place ex:12591507
+upgrade_deposit=#The upgrade deposit ex: 1000
+
+
+
+
+
+top_self_delegation_address=# Self delegation address of the top validator in the network
+top_self_delegation_public_key=# Self delegation public key of the top validator in the network
+top_operator_address=# The valoperator address of the validator
+top_operator_pubkey=# The valoper public key of the validator
+top_hexaddr=# The hex address of the validator
+top_consensus_address=# The consensus address of the validator

--- a/Mainnet_fork/inventory.ini
+++ b/Mainnet_fork/inventory.ini
@@ -5,7 +5,7 @@ server ansible_host=a.b.c.d ansible_user=root
 [all:vars]
 
 user_home="{{ ansible_env.HOME }}"
-path="/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:/{{ user_home }}/go/bin"
+path="/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:{{ user_home }}/go/bin"
 network= #github repo name ex: passage
 node_home= #the node home for the chain ex:'.passage'
 daemon= #the daemon name of the network ex:passage

--- a/Mainnet_fork/main.yml
+++ b/Mainnet_fork/main.yml
@@ -1,0 +1,46 @@
+---
+- name: Installations
+  hosts: IP
+  roles:
+    - installations
+
+- name: Validator setup
+  hosts: IP
+  gather_facts: yes
+  roles:
+    - validator-setup
+
+- name: Cosmos Genesis Tinkerer Setup
+  hosts: IP
+  roles:
+    - cosmos-genesis-tinkerer-setup
+
+- name: Node config changes
+  hosts: IP
+  gather_facts: yes
+  roles:
+    - node_config_changes
+
+- name: Cosmosvisor setup
+  hosts: IP
+  gather_facts: yes
+  roles:
+    - cosmovisor-setup
+
+- name: Explorer setup
+  hosts: IP
+  gather_facts: yes
+  roles:
+    - explorer_setup
+
+- name: Faucet setup
+  hosts: IP
+  gather_facts: yes
+  roles:
+    - faucet_setup
+
+- name: Proposal submission
+  hosts: IP
+  gather_facts: yes
+  roles:
+    - proposal_submission

--- a/Mainnet_fork/roles/cosmos-genesis-tinkerer-setup/tasks/main.yml
+++ b/Mainnet_fork/roles/cosmos-genesis-tinkerer-setup/tasks/main.yml
@@ -19,7 +19,6 @@
   copy:
     src: "{{ state_export_file_path }}"
     dest: "{{ user_home }}/cosmos-genesis-tinkerer/state_export.json"
-    remote_src: yes
   when: state_export_file_path !=""
 
 - name: Copy the example_mainnet_genesis.py file

--- a/Mainnet_fork/roles/cosmos-genesis-tinkerer-setup/tasks/main.yml
+++ b/Mainnet_fork/roles/cosmos-genesis-tinkerer-setup/tasks/main.yml
@@ -3,7 +3,7 @@
   set_fact:
     sdk_version_clean: "{{ sdk_version | regex_replace('^v', '') }}"
 
-- name: Debug node version clean
+- name: Debug sdk version clean
   debug:
     msg: "Node version clean is {{ sdk_version_clean }}"
 
@@ -12,6 +12,8 @@
     repo: "https://github.com/hyphacoop/cosmos-genesis-tinkerer.git"
     dest: "{{ user_home }}/cosmos-genesis-tinkerer"
     version: "main"
+    update: yes
+    force: yes
 
 - name: Move the state export file inside the cosmos-genesis-tinkerer repo
   copy:
@@ -220,14 +222,14 @@
       set_fact:
         faucet_key: "{{ faucet_key_json.stdout | from_json }}"
 
-    - name: Add genesis account  for faucet
+    - name: Add genesis account for faucet (<0.50)
       when: sdk_version_clean is version('0.50.0', '<')
       become: true
       command: "{{ daemon }} add-genesis-account faucet  100000000000{{ denom }}"
       environment:
         PATH: "{{ path }}"
 
-    - name: Add genesis account  for faucet
+    - name: Add genesis account for faucet (>=0.50)
       when: sdk_version_clean is version('0.50.0', '>=')
       become: true
       command: "{{ daemon }} genesis add-genesis-account faucet  100000000000{{ denom }}"

--- a/Mainnet_fork/roles/cosmos-genesis-tinkerer-setup/tasks/main.yml
+++ b/Mainnet_fork/roles/cosmos-genesis-tinkerer-setup/tasks/main.yml
@@ -1,0 +1,241 @@
+---
+- name: Normalize sdk version (strip leading v)
+  set_fact:
+    sdk_version_clean: "{{ sdk_version | regex_replace('^v', '') }}"
+
+- name: Debug node version clean
+  debug:
+    msg: "Node version clean is {{ sdk_version_clean }}"
+
+- name: Clone the git repo
+  git:
+    repo: "https://github.com/hyphacoop/cosmos-genesis-tinkerer.git"
+    dest: "{{ user_home }}/cosmos-genesis-tinkerer"
+    version: "main"
+
+- name: Move the state export file inside the cosmos-genesis-tinkerer repo
+  copy:
+    src: "{{ state_export_file_path }}"
+    dest: "{{ user_home }}/cosmos-genesis-tinkerer/state_export.json"
+    remote_src: yes
+  when: state_export_file_path !=""
+
+- name: Copy the example_mainnet_genesis.py file
+  copy:
+    src: "{{ user_home }}/cosmos-genesis-tinkerer/example_mainnet_genesis.py"
+    dest: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+    remote_src: yes
+    mode: "0755"
+
+- name: Changes in the {{ network }}.py
+  block:
+    - name: Replace the GENESIS_ARCHIVE filename
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'GENESIS_ARCHIVE\s*=\s*".*"'
+        replace: 'GENESIS_ARCHIVE = "state_export.json"'
+
+    - name: Replace the self_delegation_address
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'cb_val\.self_delegation_address\s*=\s*".*"'
+        replace: 'cb_val.self_delegation_address = "{{ top_self_delegation_address }}"'
+
+    - name: Replace the self_delegation_reward_address
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'cb_val\.self_delegation_reward_address\s*=\s*".*"'
+        replace: 'cb_val.self_delegation_reward_address = "{{ top_self_delegation_address }}"'
+
+    - name: Replace the self_delegation_public_key
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'cb_val\.self_delegation_public_key\s*=\s*".*"'
+        replace: 'cb_val.self_delegation_public_key = "{{ top_self_delegation_public_key }}"'
+
+    - name: Replace the operator_address
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'cb_val\.operator_address\s*=\s*".*"'
+        replace: 'cb_val.operator_address = "{{ top_operator_address }}"'
+
+    - name: Replace the public_key
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'cb_val\.public_key\s*=\s*".*"'
+        replace: 'cb_val.public_key = "{{ top_operator_pubkey }}"'
+
+    - name: Replace the hex address
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'cb_val\.address\s*=\s*".*"'
+        replace: 'cb_val.address = "{{ top_hexaddr }}"'
+
+    - name: Replace the consensus_address
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'cb_val\.consensus_address\s*=\s*".*"'
+        replace: 'cb_val.consensus_address = "{{ top_consensus_address }}"'
+
+    - name: Replace the test delegation address
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'test_val\.self_delegation_address\s*=\s*".*"'
+        replace: 'test_val.self_delegation_address = "{{ self_delegation_address[0] }}"'
+
+    - name: Replace the test delegation reward address
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'test_val\.self_delegation_reward_address\s*=\s*".*"'
+        replace: 'test_val.self_delegation_reward_address = "{{ self_delegation_address[0] }}"'
+
+    - name: Replace the test delegation public key
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'test_val\.self_delegation_public_key\s*=\s*".*"'
+        replace: 'test_val.self_delegation_public_key = "{{ self_delegation_pubkey[0] }}"'
+
+    - name: Replace the test operator address
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'test_val\.operator_address\s*=\s*".*"'
+        replace: 'test_val.operator_address = "{{ operator_address[0] }}"'
+
+    - name: Replace the test public key
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'test_val\.public_key\s*=\s*".*"'
+        replace: 'test_val.public_key = "{{ operator_pubkey }}"'
+
+    - name: Replace the test hex address
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'test_val\.address\s*=\s*".*"'
+        replace: 'test_val.address = "{{ hex_address }}"'
+
+    - name: Replace the test consensus address
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'test_val\.consensus_address\s*=\s*".*"'
+        replace: 'test_val.consensus_address = "{{ consensus_address }}"'
+
+    - name: Replace the test delegation address
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'test_del\.address\s*=\s*".*"'
+        replace: 'test_del.address = "{{ self_delegation_address[0] }}"'
+
+    - name: Replace the test delegation public key
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'test_del\.public_key\s*=\s*".*"'
+        replace: 'test_del.public_key = "{{ self_delegation_pubkey[0] }}"'
+
+    - name: Increase  the UATOM_STAKE_INCREASE
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'UATOM_STAKE_INCREASE\s*=\s*.*$'
+        replace: "UATOM_STAKE_INCREASE = 5500000000000 * 1000000"
+
+    - name: Increase the UATOM_LIQUID_TOKEN_INCREASE
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+        regexp: 'UATOM_LIQUID_TOKEN_INCREASE\s*=\s*.*$'
+        replace: "UATOM_LIQUID_TOKEN_INCREASE = 1750000000000 * 1000000"
+
+#########################################################################
+
+- name: Apply code changes to cosmos_genesis_tinker.py
+  when: sdk_version_clean is version('0.50.0', '<')
+  block:
+    - name: Replace `consensus` validators with top-level validators
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/cosmos_genesis_tinker.py"
+        regexp: 'return\s+self\.genesis\["consensus"\]\["validators"\]'
+        replace: 'return self.genesis["validators"]'
+
+    - name: Update set_min_deposit to use deposit_params
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/cosmos_genesis_tinker.py"
+        regexp: '(?s)(def set_min_deposit\(.*?\).*?\n(?:.*?\n)*?\s*)params\s*=\s*self\.gov\["params"\]'
+        replace: '\1params = self.gov["deposit_params"]'
+
+    - name: Update setTallyParam function to use tally_params
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/cosmos_genesis_tinker.py"
+        regexp: 'self\.gov\["params"\]\[parameter_name\]\s*=\s*value'
+        replace: 'self.gov["tally_params"][parameter_name] = value'
+
+    - name: Update voting period function to use voting_params
+      ansible.builtin.replace:
+        path: "{{ user_home }}/cosmos-genesis-tinkerer/cosmos_genesis_tinker.py"
+        regexp: 'self\.gov\["params"\]\["voting_period"\]\s*=\s*voting_period'
+        replace: 'self.gov["voting_params"]["voting_period"] = voting_period'
+
+- name: Replace all "uatom" with value of denom variable in the tinker file
+  ansible.builtin.replace:
+    path: "{{ user_home }}/cosmos-genesis-tinkerer/cosmos_genesis_tinker.py"
+    regexp: "uatom"
+    replace: "{{ denom }}"
+
+- name: Replace 'uatom' with denom in network.py file
+  ansible.builtin.replace:
+    path: "{{ user_home }}/cosmos-genesis-tinkerer/{{ network }}.py"
+    regexp: "'uatom'"
+    replace: "'{{ denom }}'"
+
+- name: Run the python application
+  block:
+    - name: Create Python virtual environment
+      command: python3 -m venv .env
+      args:
+        chdir: "{{ user_home }}/cosmos-genesis-tinkerer"
+
+    - name: Install pip requirements inside venv
+      command: "{{ user_home }}/cosmos-genesis-tinkerer/.env/bin/pip install -r requirements.txt"
+      args:
+        chdir: "{{ user_home }}/cosmos-genesis-tinkerer"
+
+    - name: Run {{ network }}.py with python3
+      command: "python3 {{ network }}.py"
+      args:
+        chdir: "{{ user_home }}/cosmos-genesis-tinkerer"
+
+- name: Copy the generated genesis file to validator and fullnode directories
+  block:
+    - name: Copy the genesis file to validator directory
+      copy:
+        src: "{{ user_home }}/cosmos-genesis-tinkerer/tinkered_genesis.json"
+        dest: "{{ user_home }}/{{ node_home }}/config/genesis.json"
+        remote_src: yes
+
+    - name: Add faucet key
+      become: true
+      command: "{{ daemon }} keys add faucet --output json"
+      environment:
+        PATH: "{{ path }}"
+      register: faucet_key_json
+
+    - name: Parse faucet key json
+      set_fact:
+        faucet_key: "{{ faucet_key_json.stdout | from_json }}"
+
+    - name: Add genesis account  for faucet
+      when: sdk_version_clean is version('0.50.0', '<')
+      become: true
+      command: "{{ daemon }} add-genesis-account faucet  100000000000{{ denom }}"
+      environment:
+        PATH: "{{ path }}"
+
+    - name: Add genesis account  for faucet
+      when: sdk_version_clean is version('0.50.0', '>=')
+      become: true
+      command: "{{ daemon }} genesis add-genesis-account faucet  100000000000{{ denom }}"
+      environment:
+        PATH: "{{ path }}"
+
+    - name: Copy the genesis file to fullnode directory
+      copy:
+        src: "{{ user_home }}/{{ node_home }}/config/genesis.json"
+        dest: "{{ user_home }}/{{ node_home }}_fullnode/config/genesis.json"
+        remote_src: yes

--- a/Mainnet_fork/roles/cosmovisor-setup/tasks/main.yml
+++ b/Mainnet_fork/roles/cosmovisor-setup/tasks/main.yml
@@ -1,0 +1,126 @@
+- name: Debug ansible_user
+  debug:
+    msg: "Ansible user for this host is {{ ansible_user }}, home is {{ user_home }}"
+
+- name: Install cosmovisor
+  command: go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
+  environment:
+    PATH: "{{ path }}"
+
+- name: Create cosmovisor directories for validator
+  file:
+    path: "{{ user_home }}/{{ node_home }}/cosmovisor/{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - genesis/bin
+    - upgrades/{{ network_upgrade_name }}/bin
+
+- name: Copy the binary into the cosmovisor directory for validator
+  copy:
+    src: "{{ user_home }}/go/bin/{{ daemon }}"
+    dest: "{{ user_home }}/{{ node_home }}/cosmovisor/genesis/bin/{{ daemon }}"
+    mode: "0755"
+    remote_src: yes
+
+- name: Create cosmovisor directories for fullnode
+  file:
+    path: "{{ user_home }}/{{ node_home }}_fullnode/cosmovisor/{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - genesis/bin
+    - upgrades/{{ network_upgrade_name }}/bin
+
+- name: Change ownership of validator cosmovisor directory
+  become: true
+  file:
+    path: "{{ user_home }}/{{ node_home }}/cosmovisor"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    recurse: yes
+
+- name: Change ownership of fullnode cosmovisor directory
+  become: true
+  file:
+    path: "{{ user_home }}/{{ node_home }}_fullnode/cosmovisor"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    recurse: yes
+
+- name: Copy the binary into the cosmovisor directory for fullnode
+  copy:
+    src: "{{ user_home }}/go/bin/{{ daemon }}"
+    dest: "{{ user_home }}/{{ node_home }}_fullnode/cosmovisor/genesis/bin/{{ daemon }}"
+    mode: "0755"
+    remote_src: yes
+
+- name: Ensure cosmovisor current symlink for validator
+  file:
+    src: "{{ user_home }}/{{ node_home }}/cosmovisor/genesis"
+    dest: "{{ user_home }}/{{ node_home }}/cosmovisor/current"
+    state: link
+
+- name: Ensure cosmovisor current symlink for fullnode
+  file:
+    src: "{{ user_home }}/{{ node_home }}_fullnode/cosmovisor/genesis"
+    dest: "{{ user_home }}/{{ node_home }}_fullnode/cosmovisor/current"
+    state: link
+
+- name: Deploy validator systemd service
+  template:
+    src: "{{ playbook_dir }}/templates/validator-service.j2"
+    dest: /etc/systemd/system/{{ daemon }}-validator.service
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: "0644"
+
+- name: Reload systemd and enable service
+  systemd:
+    name: "{{ daemon }}-validator"
+    enabled: true
+    daemon_reload: true
+    state: started
+
+- name: Deploy fullnode systemd service
+  template:
+    src: "{{ playbook_dir }}/templates/fullnode-service.j2"
+    dest: /etc/systemd/system/{{ daemon }}-fullnode.service
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: "0644"
+
+- name: Reload systemd and enable service
+  systemd:
+    name: "{{ daemon }}-fullnode"
+    enabled: true
+    daemon_reload: true
+    state: started
+
+- name: Checkout to network_upgrade_version
+  become: true
+  ansible.builtin.command: git checkout "{{ network_upgrade_version }}"
+  args:
+    chdir: "{{ user_home }}/{{ network }}"
+
+- name: Build the upgrade
+  become: true
+  ansible.builtin.command: make build
+  environment:
+    PATH: "{{ path }}"
+  args:
+    chdir: "{{ user_home }}/{{ network }}"
+
+- name: Copy the binary into the cosmovisor directory for validator upgrade
+  copy:
+    src: "{{ user_home }}/{{ network }}/build/{{ daemon }}"
+    dest: "{{ user_home }}/{{ node_home }}/cosmovisor/upgrades/{{ network_upgrade_name }}/bin/{{ daemon }}"
+    mode: "0755"
+    remote_src: yes
+
+- name: Copy the binary into the cosmovisor directory for fullnode upgrade
+  copy:
+    src: "{{ user_home }}/{{ network }}/build/{{ daemon }}"
+    dest: "{{ user_home }}/{{ node_home }}_fullnode/cosmovisor/upgrades/{{ network_upgrade_name }}/bin/{{ daemon }}"
+    mode: "0755"
+    remote_src: yes

--- a/Mainnet_fork/roles/cosmovisor-setup/tasks/main.yml
+++ b/Mainnet_fork/roles/cosmovisor-setup/tasks/main.yml
@@ -68,6 +68,7 @@
     state: link
 
 - name: Deploy validator systemd service
+  become: true
   template:
     src: "{{ playbook_dir }}/templates/validator-service.j2"
     dest: /etc/systemd/system/{{ daemon }}-validator.service
@@ -76,6 +77,7 @@
     mode: "0644"
 
 - name: Reload systemd and enable service
+  become: true
   systemd:
     name: "{{ daemon }}-validator"
     enabled: true
@@ -83,6 +85,7 @@
     state: started
 
 - name: Deploy fullnode systemd service
+  become: true
   template:
     src: "{{ playbook_dir }}/templates/fullnode-service.j2"
     dest: /etc/systemd/system/{{ daemon }}-fullnode.service
@@ -91,6 +94,7 @@
     mode: "0644"
 
 - name: Reload systemd and enable service
+  become: true
   systemd:
     name: "{{ daemon }}-fullnode"
     enabled: true

--- a/Mainnet_fork/roles/explorer_setup/tasks/main.yml
+++ b/Mainnet_fork/roles/explorer_setup/tasks/main.yml
@@ -1,0 +1,108 @@
+---
+- name: Create NVM directory
+  file:
+    path: "{{ user_home }}/.nvm"
+    state: directory
+    mode: "0755"
+
+- name: Download nvm installer with curl
+  command: curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh -o {{ user_home }}/install_nvm.sh
+  args:
+    creates: "{{ user_home }}/install_nvm.sh"
+  environment:
+    HOME: "{{ user_home }}"
+
+- name: Run nvm install script
+  shell: bash "{{ user_home }}/install_nvm.sh"
+  args:
+    executable: /bin/bash
+  environment:
+    NVM_DIR: "{{ user_home }}/.nvm"
+
+- name: Install Node.js
+  shell: >
+    . "{{ user_home }}/.nvm/nvm.sh" &&
+    nvm install v18.19.0
+  environment:
+    NVM_DIR: "{{ user_home }}/.nvm"
+    PATH: "{{ user_home }}/.nvm/versions/node/v18.19.0/bin:{{ ansible_env.PATH }}"
+
+- name: Update user's PATH in .bashrc
+  lineinfile:
+    path: "{{ user_home }}/.bashrc"
+    line: 'export PATH="{{ user_home }}/.nvm/versions/node/v18.19.0/bin:$PATH"'
+  become_user: "{{ ansible_user }}"
+
+- name: Install npm
+  shell: >
+    . "{{ user_home }}/.nvm/nvm.sh" &&
+    nvm install-latest-npm
+  environment:
+    NVM_DIR: "{{ user_home }}/.nvm"
+    PATH: "{{ user_home }}/.nvm/versions/node/v18.19.0/bin:{{ ansible_env.PATH }}"
+
+- name: Install yarn
+  become: true
+  shell: >
+    . "{{ user_home }}/.nvm/nvm.sh" &&
+    npm install --global --unsafe-perm=true yarn
+  environment:
+    NVM_DIR: "{{ user_home }}/.nvm"
+    PATH: "{{ user_home }}/.nvm/versions/node/v18.19.0/bin:{{ ansible_env.PATH }}"
+
+- name: Install ping_explorer
+  become: true
+  git:
+    repo: "{{ ping_repo }}"
+    dest: "{{ user_home }}/explorer"
+    version: "f0120a4a9f1a96f596139f36a9030fd05f227d8b"
+
+- name: Install nginx
+  become: true
+  apt:
+    name: nginx
+    state: present
+    update_cache: yes
+
+- name: Remove contents of mainnet directory
+  file:
+    path: "{{ user_home }}/explorer/chains/mainnet"
+    state: absent
+  become: true
+
+- name: Recreate mainnet directory
+  file:
+    path: "{{ user_home }}/explorer/chains/mainnet"
+    state: directory
+  become: true
+
+- name: Copy the sample json file
+  become: true
+  template:
+    src: "{{ playbook_dir }}/templates/explorer-config.j2"
+    dest: "{{ user_home }}/explorer/chains/mainnet/local-testnet.json"
+
+- name: Remove contents of /var/www/html
+  become: true
+  file:
+    path: "/var/www/html/"
+    state: absent
+
+- name: Recreate /var/www/html directory
+  become: true
+  file:
+    path: "/var/www/html/"
+    state: directory
+
+- name: Build the explorer
+  become: true
+  shell: >
+    . "{{ user_home }}/.nvm/nvm.sh" && export PATH="{{ ansible_env.PATH }}:{{ user_home }}/.nvm/versions/node/v18.19.0/bin" && cd '{{ user_home }}/explorer' && yarn install --ignore-engines && yarn build
+  args:
+    chdir: "{{ user_home }}/explorer"
+
+- name: Move the data inside dist folder to /var/www/html
+  become: true
+  shell: cp -r dist/* /var/www/html/
+  args:
+    chdir: "{{ user_home }}/explorer"

--- a/Mainnet_fork/roles/explorer_setup/tasks/main.yml
+++ b/Mainnet_fork/roles/explorer_setup/tasks/main.yml
@@ -51,7 +51,6 @@
     PATH: "{{ user_home }}/.nvm/versions/node/v18.19.0/bin:{{ ansible_env.PATH }}"
 
 - name: Install ping_explorer
-  become: true
   git:
     repo: "{{ ping_repo }}"
     dest: "{{ user_home }}/explorer"

--- a/Mainnet_fork/roles/faucet_setup/tasks/main.yml
+++ b/Mainnet_fork/roles/faucet_setup/tasks/main.yml
@@ -1,0 +1,73 @@
+- name: Install the faucet
+  become: true
+  git:
+    repo: "https://github.com/vitwit/ping-faucet.git"
+    dest: "{{ user_home }}/faucet"
+    version: "multi-chains"
+    force: yes
+
+- name: Remove existing config.js file
+  become: true
+  file:
+    path: "{{ user_home }}/faucet/config.js"
+    state: absent
+
+- name: Copy the config.js file
+  become: true
+  template:
+    src: "{{ playbook_dir }}/templates/faucet-config.j2"
+    dest: "{{ user_home }}/faucet/config.js"
+
+- name: Install express using npm
+  become: true
+  shell: >
+    . "{{ user_home }}/.nvm/nvm.sh" &&
+    export PATH="{{ user_home }}/.nvm/versions/node/v18.19.0/bin:$PATH" &&
+    npm install express
+  args:
+    chdir: "{{ user_home }}/faucet"
+
+- name: Run yarn
+  become: true
+  shell: >
+    . "{{ user_home }}/.nvm/nvm.sh" &&
+    export PATH="{{ user_home }}/.nvm/versions/node/v18.19.0/bin:$PATH" &&
+    yarn
+  args:
+    chdir: "{{ user_home }}/faucet"
+
+- name: Copy the service file
+  become: true
+  template:
+    src: "{{ playbook_dir }}/templates/faucet-service.j2"
+    dest: "/etc/systemd/system/faucet.service"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Create faucet data directory
+  file:
+    path: "{{ user_home }}/faucet/.faucet"
+    state: directory
+    owner: "{{ ansible_user }}"
+    mode: "0755"
+
+- name: Save faucet mnemonic to file
+  copy:
+    dest: "{{ user_home }}/faucet/.faucet/mnemonic.txt"
+    content: "{{ faucet_key.mnemonic }}\n"
+    owner: "{{ ansible_user }}"
+    mode: "0600"
+
+- name: Update config.js with faucet mnemonic
+  lineinfile:
+    path: "{{ user_home }}/faucet/config.js"
+    regexp: '^\s*mnemonic:\s*"([^"]*)"'
+    line: 'mnemonic: "{{ faucet_key.mnemonic }}",'
+
+- name: Start the faucet service
+  become: true
+  systemd:
+    name: faucet
+    state: started
+    enabled: yes

--- a/Mainnet_fork/roles/faucet_setup/tasks/main.yml
+++ b/Mainnet_fork/roles/faucet_setup/tasks/main.yml
@@ -14,9 +14,13 @@
 
 - name: Copy the config.js file
   become: true
+  become_user: "{{ ansible_user }}"
   template:
     src: "{{ playbook_dir }}/templates/faucet-config.j2"
     dest: "{{ user_home }}/faucet/config.js"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: "0644"
 
 - name: Install express using npm
   become: true
@@ -71,3 +75,4 @@
     name: faucet
     state: started
     enabled: yes
+    daemon_reload: yes

--- a/Mainnet_fork/roles/installations/tasks/main.yml
+++ b/Mainnet_fork/roles/installations/tasks/main.yml
@@ -69,6 +69,7 @@
   become: true
   block:
     - name: Clone the git repo
+      become_user: "{{ ansible_user }}"
       git:
         repo: "{{ repo }}"
         dest: "{{ user_home }}/{{ network }}"
@@ -77,6 +78,7 @@
         force: yes
 
     - name: Install node
+      become_user: "{{ ansible_user }}"
       command: "make install"
       args:
         chdir: "{{ user_home }}/{{ network }}"

--- a/Mainnet_fork/roles/installations/tasks/main.yml
+++ b/Mainnet_fork/roles/installations/tasks/main.yml
@@ -1,0 +1,98 @@
+---
+- name: Debug the user dir
+  debug:
+    msg: "User Directory: {{ user_home }}"
+
+- name: Download go tar file
+  command: curl -L https://go.dev/dl/go{{ go_version }}.linux-amd64.tar.gz -o /tmp/go{{ go_version }}.linux-amd64.tar.gz
+  args:
+    warn: false
+  become: true
+
+- name: Delete previous installation
+  file:
+    path: /usr/local/go
+    state: absent
+  become: true
+
+- name: Extract and move new go folder to /usr/local
+  unarchive:
+    src: /tmp/go{{go_version}}.linux-amd64.tar.gz
+    dest: /usr/local
+    remote_src: yes
+  become: true
+
+- name: Delete downloaded tar file
+  file:
+    path: /tmp/go{{go_version}}.linux-amd64.tar.gz
+    state: absent
+  become: true
+
+- name: Set Go environment variables in ~/.profile
+  lineinfile:
+    path: ~/.profile
+    line: |
+      export GOROOT=/usr/local/go
+      export GOPATH={{ user_home }}/go
+      export GOBIN=$GOPATH/bin
+      export PATH=$PATH:/usr/local/go/bin:$GOBIN
+    create: true
+    state: present
+
+- name: sleep for a few seconds
+  pause:
+    seconds: 20
+
+- name: Update apt package list
+  become: true
+  apt:
+    update_cache: yes
+
+- name: sleep for a few seconds
+  pause:
+    seconds: 20
+
+- name: Install prerequisites
+  become: true
+  apt:
+    name:
+      - make
+      - jq
+      - gcc
+    state: present
+
+- name: Debug the  dir
+  debug:
+    msg: "User Directory: {{ user_home }}"
+
+- name: Install the binary
+  become: true
+  block:
+    - name: Clone the git repo
+      git:
+        repo: "{{ repo }}"
+        dest: "{{ user_home }}/{{ network }}"
+        version: "{{ node_version }}"
+        update: yes
+        force: yes
+
+    - name: Install node
+      command: "make install"
+      args:
+        chdir: "{{ user_home }}/{{ network }}"
+      environment:
+        PATH: "{{ path }}"
+        GOPATH: "{{ user_home }}/go"
+
+- name: Install python3-venv
+  apt:
+    name: python3-venv
+    state: present
+  become: true
+
+- name: Install pip
+  become: true
+  apt:
+    name: python3-pip
+    state: present
+    update_cache: yes

--- a/Mainnet_fork/roles/installations/tasks/main.yml
+++ b/Mainnet_fork/roles/installations/tasks/main.yml
@@ -5,8 +5,6 @@
 
 - name: Download go tar file
   command: curl -L https://go.dev/dl/go{{ go_version }}.linux-amd64.tar.gz -o /tmp/go{{ go_version }}.linux-amd64.tar.gz
-  args:
-    warn: false
   become: true
 
 - name: Delete previous installation

--- a/Mainnet_fork/roles/node_config_changes/tasks/main.yml
+++ b/Mainnet_fork/roles/node_config_changes/tasks/main.yml
@@ -1,0 +1,127 @@
+- name: Change ports for fullnode
+  block:
+    - name: Change P2P port for fullnode
+      ansible.builtin.replace:
+        path: "{{ user_home }}/{{ node_home }}_fullnode/config/config.toml"
+        regexp: '^laddr = "tcp://0.0.0.0:26656"'
+        replace: 'laddr = "tcp://0.0.0.0:26666"'
+
+    - name: Change RPC port for fullnode
+      ansible.builtin.replace:
+        path: "{{ user_home }}/{{ node_home }}_fullnode/config/config.toml"
+        regexp: '^laddr = "tcp://127.0.0.1:26657"'
+        replace: 'laddr = "tcp://0.0.0.0:26667"'
+
+    - name: Change REST API port for fullnode
+      when: sdk_version_clean is version('0.50.0', '<')
+      ansible.builtin.replace:
+        path: "{{ user_home }}/{{ node_home }}_fullnode/config/app.toml"
+        regexp: '^address = "tcp://0.0.0.0:1317"'
+        replace: 'address = "tcp://0.0.0.0:1318"'
+
+    - name: Change REST API port for fullnode
+      when: sdk_version_clean is version('0.50.0', '>=')
+      ansible.builtin.replace:
+        path: "{{ user_home }}/{{ node_home }}_fullnode/config/app.toml"
+        regexp: '^address = "tcp://localhost:1317"'
+        replace: 'address = "tcp://0.0.0.0:1318"'
+
+    - name: Change gRPC port for fullnode
+      when: sdk_version_clean is version('0.50.0', '<')
+      ansible.builtin.replace:
+        path: "{{ user_home }}/{{ node_home }}_fullnode/config/app.toml"
+        regexp: '^address = "0.0.0.0:9090"'
+        replace: 'address = "0.0.0.0:9093"'
+
+    - name: Change gRPC port for fullnode
+      when: sdk_version_clean is version('0.50.0', '>=')
+      ansible.builtin.replace:
+        path: "{{ user_home }}/{{ node_home }}_fullnode/config/app.toml"
+        regexp: '^address = "localhost:9090"'
+        replace: 'address = "0.0.0.0:9093"'
+
+    - name: Change gRPC-web port for fullnode
+      ansible.builtin.replace:
+        path: "{{ user_home }}/{{ node_home }}_fullnode/config/app.toml"
+        regexp: '^address = "0.0.0.0:9091"'
+        replace: 'address = "0.0.0.0:9094"'
+
+    - name: Making the change in the CORS section of config.toml
+      become: true
+      lineinfile:
+        path: "{{ user_home }}/{{ node_home }}_fullnode/config/config.toml"
+        regexp: 'cors_allowed_origins = \[\]'
+        line: 'cors_allowed_origins = ["*"]'
+
+    - name: Making the change in the CORS section of app.toml
+      become: true
+      lineinfile:
+        path: "{{ user_home }}/{{ node_home }}_fullnode/config/app.toml"
+        regexp: "enabled-unsafe-cors = false"
+        line: "enabled-unsafe-cors = true"
+
+    - name: set enable to true under api section
+      become: true
+      replace:
+        path: "{{ user_home }}/{{ node_home }}_fullnode/config/app.toml"
+        regexp: '(?ms)(\[api\][^\[]*enable\s*=\s*)false'
+        replace: '\1true'
+
+- name: Changes to validator config files
+  block:
+    - name: Make RPC accessible
+      ansible.builtin.replace:
+        path: "{{ user_home }}/{{ node_home }}/config/config.toml"
+        regexp: '^laddr = "tcp://127.0.0.1:26657"'
+        replace: 'laddr = "tcp://0.0.0.0:26657"'
+
+    - name: Making the change in the CORS section of config.toml
+      become: true
+      lineinfile:
+        path: "{{ user_home }}/{{ node_home }}/config/config.toml"
+        regexp: 'cors_allowed_origins = \[\]'
+        line: 'cors_allowed_origins = ["*"]'
+
+    - name: Making the change in the CORS section of app.toml
+      become: true
+      lineinfile:
+        path: "{{ user_home }}/{{ node_home }}/config/app.toml"
+        regexp: "enabled-unsafe-cors = false"
+        line: "enabled-unsafe-cors = true"
+
+    - name: set enable to true under api section
+      become: true
+      replace:
+        path: "{{ user_home }}/{{ node_home }}/config/app.toml"
+        regexp: '(?ms)(\[api\][^\[]*enable\s*=\s*)false'
+        replace: '\1true'
+
+    - name: Change REST API port for validator
+      when: sdk_version_clean is version('0.50.0', '>=')
+      ansible.builtin.replace:
+        path: "{{ user_home }}/{{ node_home }}/config/app.toml"
+        regexp: '^address = "tcp://localhost:1317"'
+        replace: 'address = "tcp://0.0.0.0:1317"'
+
+    - name: Change gRPC port for validator
+      when: sdk_version_clean is version('0.50.0', '>=')
+      ansible.builtin.replace:
+        path: "{{ user_home }}/{{ node_home }}/config/app.toml"
+        regexp: '^address = "localhost:9090"'
+        replace: 'address = "0.0.0.0:9090"'
+
+- name: Set minimum gas price
+  block:
+    - name: Set minimum gas price for validator
+      become: true
+      lineinfile:
+        path: "{{ user_home }}/{{ node_home }}/config/app.toml"
+        regexp: '^minimum-gas-prices\s*='
+        line: 'minimum-gas-prices = "{{ minimum_gas_price }}"'
+
+    - name: Set minimum gas price for fullnode
+      become: true
+      lineinfile:
+        path: "{{ user_home }}/{{ node_home }}_fullnode/config/app.toml"
+        regexp: '^minimum-gas-prices\s*='
+        line: 'minimum-gas-prices = "{{ minimum_gas_price }}"'

--- a/Mainnet_fork/roles/proposal_submission/tasks/main.yml
+++ b/Mainnet_fork/roles/proposal_submission/tasks/main.yml
@@ -1,0 +1,170 @@
+- name: Normalize sdk version
+  set_fact:
+    sdk_version_short: "{{ sdk_version | regex_replace('^v', '') | regex_replace('\\.\\d+$', '') }}"
+  # Example: v0.45.16 → 0.45
+- name: Debug node version short
+  debug:
+    msg: "Node version short is {{ sdk_version_short }}"
+
+- name: Query gov module account address
+  command: "{{ daemon }} q auth module-account gov --output json"
+  register: gov_account
+  environment:
+    PATH: "{{ path }}"
+  when: sdk_version_short is version('0.50', '>=')
+
+- name: Set gov module address fact
+  set_fact:
+    gov_address: "{{ (gov_account.stdout | from_json).account.value.address }}"
+  when: sdk_version_short is version('0.50', '>=')
+
+- name: Debug gov module address
+  debug:
+    msg: "Gov module address is {{ gov_address }}"
+  when: sdk_version_short is version('0.50', '>=')
+
+# ----------------- 0.45 -----------------
+- name: Submit upgrade proposal for 0.45
+  shell: |
+    {{ daemon }} tx gov submit-proposal software-upgrade "{{ network_upgrade_name }}" \
+      --title "Upgrade to {{ network_upgrade_version }}" \
+      --description "Upgrade chain binary to {{ network_upgrade_version }}" \
+      --upgrade-height {{ upgrade_height }} \
+      --from {{ validator_name }} \
+      --keyring-backend test \
+      --deposit {{ upgrade_deposit }}{{ denom }} \
+      --chain-id local-testnet \
+      --fees 35000000{{ denom }} \
+      --home {{ user_home }}/{{ node_home }} -y \
+      --broadcast-mode block \
+      --gas auto --gas-adjustment 1.5 \
+      --output json
+  when: sdk_version_short == '0.45'
+  args:
+    executable: /bin/bash
+  environment:
+    PATH: "{{ path }}"
+  register: proposal_tx
+
+# ----------------- 0.46 / 0.47 -----------------
+- name: Submit upgrade proposal for 0.46 / 0.47
+  shell: |
+    {{ daemon }} tx gov submit-legacy-proposal software-upgrade "{{ network_upgrade_name }}" \
+      --title "Upgrade to {{ network_upgrade_version }}" \
+      --description "Upgrade chain binary to {{ network_upgrade_version }}" \
+      --upgrade-height {{ upgrade_height }} \
+      --upgrade-info "testing" \
+      --from {{ validator_name }} \
+      --keyring-backend test \
+      --deposit {{ upgrade_deposit }}{{ denom }} \
+      --fees 35000000{{ denom }} \
+      --chain-id local-testnet \
+      --no-validate \
+      --home {{ user_home }}/{{ node_home }} -y \
+      --broadcast-mode block \
+      --gas auto --gas-adjustment 1.5 \
+      --output json
+  when: sdk_version_short in ['0.46', '0.47']
+  args:
+    executable: /bin/bash
+  environment:
+    PATH: "{{ path }}"
+  register: proposal_tx
+#-------------------------------------------0.50-----------------------------------------------------
+- name: Write upgrade proposal JSON (0.50+)
+  copy:
+    dest: "{{ user_home }}/upgrade.json"
+    content: |
+      {
+        "messages": [
+          {
+            "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+            "authority": "{{ gov_address }}",
+            "plan": {
+              "name": "{{ network_upgrade_name }}",
+              "height": "{{ upgrade_height }}",
+              "info": "",
+              "upgraded_client_state": null
+            }
+          }
+        ],
+        "deposit": "{{ upgrade_deposit }}{{ denom }}",
+        "title": "{{ network_upgrade_version }}",
+        "summary": "Upgrade chain binary to {{ network_upgrade_version }}",
+        "expedited": false
+      }
+  when: sdk_version_short is version('0.50', '>=')
+- name: Submit software upgrade proposal (0.50+)
+  shell: |
+    {{ daemon }} tx gov submit-proposal "{{ user_home }}/upgrade.json" \
+      --from {{ validator_name }} \
+      --keyring-backend test \
+      --chain-id local-testnet \
+      --fees 35000000{{ denom }} \
+      --gas auto \
+      --gas-adjustment 1.5 \
+      --home {{ user_home }}/{{ node_home }} \
+      -y --output json
+  when: sdk_version_short is version('0.50', '>=')
+  args:
+    executable: /bin/bash
+  environment:
+    PATH: "{{ path }}"
+  register: proposal_tx
+
+- name: Debug proposal submission output
+  debug:
+    var: proposal_tx
+
+- name: Pause for 10 seconds before querying proposal
+  pause:
+    seconds: 15
+
+- name: Get latest proposal ID
+  command: "{{ daemon }} q gov proposals --output json"
+  register: proposals_json
+  environment:
+    PATH: "{{ path }}"
+
+- name: Parse latest proposal ID
+  set_fact:
+    proposal_id: >-
+      {{ (proposals_json.stdout | from_json).proposals | map(attribute='proposal_id') | map('int') | max }}
+  when: sdk_version_short in ['0.45']
+
+- name: Parse latest proposal ID (0.46/0.47)
+  set_fact:
+    proposal_id: >-
+      {{ (proposals_json.stdout | from_json).proposals
+         | map(attribute='id') | map('int') | max }}
+  when: sdk_version_short in ['0.46', '0.47']
+
+- name: Parse latest proposal ID (>=0.50)
+  set_fact:
+    proposal_id: >-
+      {{ (proposals_json.stdout | from_json).proposals
+         | map(attribute='id') | map('int') | max }}
+  when: sdk_version_short is version('0.50', '>=')
+
+- name: Show captured proposal ID
+  debug:
+    msg: "Proposal ID is {{ proposal_id }}"
+
+- name: Vote on the proposal
+  shell: |
+    {{ daemon }} tx gov vote {{ proposal_id }} yes \
+      --from {{ validator_name }} \
+      --chain-id local-testnet \
+      --gas-prices 5000{{ denom }} \
+      --keyring-backend test \
+      --gas auto --gas-adjustment 1.5 \
+      --home {{ user_home }}/{{ node_home }} -y
+  args:
+    executable: /bin/bash
+  environment:
+    PATH: "{{ path }}"
+  register: vote_account
+
+- name: Debug vote output
+  debug:
+    var: vote_account

--- a/Mainnet_fork/roles/proposal_submission/tasks/main.yml
+++ b/Mainnet_fork/roles/proposal_submission/tasks/main.yml
@@ -116,7 +116,7 @@
   debug:
     var: proposal_tx
 
-- name: Pause for 10 seconds before querying proposal
+- name: Pause for 15 seconds before querying proposal
   pause:
     seconds: 15
 

--- a/Mainnet_fork/roles/validator-setup/tasks/main.yml
+++ b/Mainnet_fork/roles/validator-setup/tasks/main.yml
@@ -1,0 +1,133 @@
+---
+- name: Initialize the node
+  become: true
+  command: "{{ daemon }} init {{ validator_name }} "
+  environment:
+    PATH: "{{ path }}"
+
+- name: Set keyring-backend to "test" in client.toml
+  become: true
+  ansible.builtin.replace:
+    path: "{{ user_home }}/{{ node_home }}/config/client.toml"
+    regexp: '^keyring-backend\s*=\s*".*"'
+    replace: 'keyring-backend = "test"'
+
+- name: Add validator key
+  become: true
+  command: "{{ daemon }} keys add {{ validator_name }}"
+  register: add_validator_key_output
+  environment:
+    PATH: "{{ path }}"
+
+- name: Extract self delegation address
+  set_fact:
+    self_delegation_address: "{{ add_validator_key_output.stdout | regex_search('address:\\s*([a-zA-Z0-9]+)', '\\1') }}"
+
+- name: Debug self delegation address
+  debug:
+    msg: "Self delegation address is {{ self_delegation_address }}"
+
+- name: Extract self delegation pubkey
+  set_fact:
+    self_delegation_pubkey: "{{ add_validator_key_output.stdout | regex_search('key\":\"([A-Za-z0-9+/=]+)\"', '\\1') }}"
+
+- name: Debug self delegation pubkey
+  debug:
+    msg: "Self delegation pubkey is {{ self_delegation_pubkey }}"
+
+- name: Extract the operator address
+  command: "{{ daemon }} keys show {{ validator_name }} --bech=val"
+  register: operator_address_output
+  environment:
+    PATH: "{{ path }}"
+
+- name: Debug operator address output
+  debug:
+    msg: "Operator address output is {{ operator_address_output.stdout }}"
+
+- name: Set operator address from command output
+  set_fact:
+    operator_address: "{{ operator_address_output.stdout | regex_search('address:\\s*(\\S+)', '\\1') }}"
+
+- name: Debug operator address
+  debug:
+    msg: "Operator address is {{ operator_address }}"
+
+- name: Read priv_validator_key.json from remote host
+  slurp:
+    src: "{{ ansible_env.HOME }}/{{ node_home }}/config/priv_validator_key.json"
+  register: slurped_priv_key
+
+- name: Decode priv_validator_key.json
+  set_fact:
+    priv_validator_data: "{{ slurped_priv_key.content | b64decode | from_json }}"
+
+- name: Set operator pubkey and hex address
+  set_fact:
+    operator_pubkey: "{{ priv_validator_data.pub_key.value }}"
+    hex_address: "{{ priv_validator_data.address }}"
+
+- name: Debug operator pubkey
+  debug:
+    var: operator_pubkey
+
+- name: Debug hex address
+  debug:
+    var: hex_address
+
+- name: Fetch the consensus address
+  command: "{{ daemon }} keys parse {{ hex_address }}"
+  register: consensus_address_output
+  environment:
+    PATH: "{{ path }}"
+
+- name: Fetch only the consensus address (valcons, not valconspub)
+  shell: >
+    {{ daemon }} keys parse {{ hex_address }}
+    | grep -Eo '[a-z0-9]+valcons[0-9a-z]+'
+    | grep -v valconspub
+    | head -n 1
+  register: consensus_address_output
+  environment:
+    PATH: "{{ path }}"
+  changed_when: false
+
+- name: Set consensus address fact
+  set_fact:
+    consensus_address: "{{ consensus_address_output.stdout }}"
+
+- name: Debug consensus address
+  debug:
+    msg: "Consensus address is {{ consensus_address }}"
+
+- name: Initialize the fullnode
+  become: true
+  command: "{{ daemon }} init {{ fullnode_name }} --home {{ user_home }}/{{ node_home }}_fullnode"
+  environment:
+    PATH: "{{ path }}"
+
+- name: Remove the default genesis file for the validator
+  become: true
+  file:
+    path: "{{ user_home }}/{{ node_home }}/config/genesis.json"
+    state: absent
+
+- name: Remove the default genesis file for the fullnode
+  become: true
+  file:
+    path: "{{ user_home }}/{{ node_home }}_fullnode/config/genesis.json"
+    state: absent
+
+- name: Extract node-id of the validator
+  become: true
+  shell: "{{ daemon }} tendermint show-node-id"
+  register: node_ids
+  environment:
+    PATH: "{{ path }}"
+
+- name: Set the persistent peer for the fullnode
+  become: true
+  lineinfile:
+    path: "{{ user_home }}/{{ node_home }}_fullnode/config/config.toml"
+    regexp: "^persistent_peers ="
+    line: 'persistent_peers = "{{ node_ids.stdout }}@{{ hostvars[inventory_hostname].ansible_host }}:26656"'

--- a/Mainnet_fork/templates/explorer-config.j2
+++ b/Mainnet_fork/templates/explorer-config.j2
@@ -1,0 +1,20 @@
+{
+    "chain_name": "local-testnet",
+    "api": [
+        {"address": "http://{{ hostvars[inventory_hostname].ansible_host }}:1317"}
+    ],
+    "rpc": [
+        {"address": "http://{{ hostvars[inventory_hostname].ansible_host }}:26657"}
+    ],
+    "sdk_version": "{{ sdk_version }}",
+    "coin_type": "118",
+    "min_tx_fee": "800",
+    "addr_prefix": "{{ addr_prefix }}",
+    "logo": "/logos/cosmos.svg",
+    "assets": [{
+        "base": "{{ denom }}",
+        "symbol": "ATOM",
+        "exponent": "6", 
+        "logo": "/logos/cosmos.svg"
+    }]
+}

--- a/Mainnet_fork/templates/faucet-config.j2
+++ b/Mainnet_fork/templates/faucet-config.j2
@@ -1,0 +1,68 @@
+import { stringToPath } from '@cosmjs/crypto'
+import fs from 'fs'
+// import { ethers } from 'ethers'
+import { Wallet, utils } from 'ethers';
+const HOME = ".faucet";
+const mnemonic_path= `${HOME}/mnemonic.txt`
+if (!fs.existsSync(mnemonic_path)) {
+    fs.mkdirSync(HOME, { recursive: true })
+    fs.writeFileSync(mnemonic_path, Wallet.fromMnemonic(
+        utils.entropyToMnemonic(utils.randomBytes(32))
+      ).mnemonic.phrase)
+}
+
+const mnemonic = fs.readFileSync(mnemonic_path, 'utf8')
+
+export default {
+    port: 83, // http port 
+    db: {
+        path: "~/.faucet.db" // save request states 
+    },
+    project: {
+        name: "Demo of Side Exchange",
+        logo: "https://side.one/favicon.ico",
+        deployer: `<a href="https://demo.side.exchange">Side Exchange</a>`
+    },
+    blockchains: [
+        {
+            name: "vitwit",
+            endpoint: {
+                // make sure that CORS is enabled in rpc section in config.toml
+                // cors_allowed_origins = ["*"]
+                rpc_endpoint: "http://{{ hostvars[inventory_hostname].ansible_host }}:26657",
+            },
+            sender: {
+                mnemonic: "",
+                option: {
+                    hdPaths: [stringToPath("m/44'/118'/0'/0/0")],
+                    prefix: "{{ addr_prefix }}" // human readable address prefix
+                }
+            },
+            tx: {
+                amount: [
+                    {
+                        denom: "{{ denom }}",
+                        amount: "10000000"
+                    },
+                ],
+                fee: {
+                    amount: [
+                        {
+                            amount: "2500000",
+                            denom: "{{ denom }}"
+                        }
+                    ],
+                    gas: "200000"
+                },
+		frequency_in_24h: "1000"	
+            },
+            limit: {
+                // how many times each wallet address is allowed in a window(24h)
+                address: 10, 
+                // how many times each ip is allowed in a window(24h),
+                // if you use proxy, double check if the req.ip is return client's ip.
+                ip: 10 
+            }
+        },        
+	]
+}	          

--- a/Mainnet_fork/templates/faucet-service.j2
+++ b/Mainnet_fork/templates/faucet-service.j2
@@ -1,0 +1,13 @@
+ [Unit]
+ Description=Faucet Service
+ After=network.target
+
+ [Service]
+ ExecStart={{ user_home }}/.nvm/versions/node/v18.19.0/bin/node --es-module-specifier-resolution=node {{ user_home }}/faucet/faucet.js
+ WorkingDirectory={{ user_home }}/faucet
+ Restart=always
+ RestartSec=3
+ LimitNOFILE=4096
+ 
+ [Install]
+ WantedBy=multi-user.target

--- a/Mainnet_fork/templates/faucet-service.j2
+++ b/Mainnet_fork/templates/faucet-service.j2
@@ -7,7 +7,7 @@
  WorkingDirectory={{ user_home }}/faucet
  Restart=always
  RestartSec=3
- LimitNOFILE=4096
+ LimitNOFILE=65536
  
  [Install]
  WantedBy=multi-user.target

--- a/Mainnet_fork/templates/fullnode-service.j2
+++ b/Mainnet_fork/templates/fullnode-service.j2
@@ -1,0 +1,19 @@
+[Unit]
+Description=FullNode Cosmovisor
+After=network-online.target
+
+[Service]
+User={{ansible_user}}
+WorkingDirectory={{ user_home }}
+ExecStart={{ user_home }}/go/bin/cosmovisor run start --home {{ user_home }}/{{ node_home }}_fullnode --x-crisis-skip-assert-invariants
+Restart=always
+RestartSec=3
+LimitNOFILE=4096
+Environment="DAEMON_NAME={{ daemon }}"
+Environment="DAEMON_HOME={{ user_home }}/{{ node_home }}_fullnode"
+Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
+Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
+Environment="PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:/{{ user_home }}/go/bin"
+
+[Install]
+WantedBy=multi-user.target

--- a/Mainnet_fork/templates/fullnode-service.j2
+++ b/Mainnet_fork/templates/fullnode-service.j2
@@ -8,12 +8,12 @@ WorkingDirectory={{ user_home }}
 ExecStart={{ user_home }}/go/bin/cosmovisor run start --home {{ user_home }}/{{ node_home }}_fullnode --x-crisis-skip-assert-invariants
 Restart=always
 RestartSec=3
-LimitNOFILE=4096
+LimitNOFILE=65536
 Environment="DAEMON_NAME={{ daemon }}"
 Environment="DAEMON_HOME={{ user_home }}/{{ node_home }}_fullnode"
 Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
 Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
-Environment="PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:/{{ user_home }}/go/bin"
+Environment="PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:{{ user_home }}/go/bin"
 
 [Install]
 WantedBy=multi-user.target

--- a/Mainnet_fork/templates/fullnode-service.j2
+++ b/Mainnet_fork/templates/fullnode-service.j2
@@ -14,6 +14,7 @@ Environment="DAEMON_HOME={{ user_home }}/{{ node_home }}_fullnode"
 Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
 Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
 Environment="PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:{{ user_home }}/go/bin"
+Environment="UNSAFE_SKIP_BACKUP=false"
 
 [Install]
 WantedBy=multi-user.target

--- a/Mainnet_fork/templates/validator-service.j2
+++ b/Mainnet_fork/templates/validator-service.j2
@@ -1,0 +1,21 @@
+[Unit]
+Description=Validator Cosmovisor
+After=network-online.target
+
+[Service]
+User={{ ansible_user }}
+WorkingDirectory={{ user_home }}
+ExecStart={{ user_home }}/go/bin/cosmovisor run start \
+  --home {{ user_home }}/{{ node_home }} \
+  --x-crisis-skip-assert-invariants
+Restart=always
+RestartSec=3
+LimitNOFILE=4096
+Environment="DAEMON_NAME={{ daemon }}"
+Environment="DAEMON_HOME={{ user_home }}/{{ node_home }}"
+Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
+Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
+Environment="PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:/{{ user_home }}/go/bin"
+
+[Install]
+WantedBy=multi-user.target

--- a/Mainnet_fork/templates/validator-service.j2
+++ b/Mainnet_fork/templates/validator-service.j2
@@ -10,12 +10,12 @@ ExecStart={{ user_home }}/go/bin/cosmovisor run start \
   --x-crisis-skip-assert-invariants
 Restart=always
 RestartSec=3
-LimitNOFILE=4096
+LimitNOFILE=65536
 Environment="DAEMON_NAME={{ daemon }}"
 Environment="DAEMON_HOME={{ user_home }}/{{ node_home }}"
 Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
 Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
-Environment="PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:/{{ user_home }}/go/bin"
+Environment="PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:{{ user_home }}/go/bin"
 
 [Install]
 WantedBy=multi-user.target

--- a/Mainnet_fork/templates/validator-service.j2
+++ b/Mainnet_fork/templates/validator-service.j2
@@ -16,6 +16,7 @@ Environment="DAEMON_HOME={{ user_home }}/{{ node_home }}"
 Environment="DAEMON_ALLOW_DOWNLOAD_BINARIES=false"
 Environment="DAEMON_RESTART_AFTER_UPGRADE=true"
 Environment="PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:{{ user_home }}/go/bin"
+Environment="UNSAFE_SKIP_BACKUP=false"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ansible-based end-to-end mainnet-fork deployment: validator + fullnode bootstrap, automated genesis tinkering, port/CORS/API updates, and minimum gas price configuration.
  * Cosmovisor install with systemd services and upgrade binary handling for validator and fullnode.
  * Explorer and faucet provisioning: environment setup, build/deploy, mnemonic/config management, and running services.
  * Governance proposal submission and voting with SDK-version-aware flows.
  * Tooling installation for Go, Node, and Python; inventory-driven configuration.

* **Documentation**
  * Added README with prerequisites, configuration notes, and deployment steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->